### PR TITLE
Add Bundler support to control Jekyll version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Icon
 .Spotlight-V100
 .Trashes
 .*
+
+# Ignore Gembile lock 
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+
+gem "github-pages", group: :jekyll_plugins

--- a/README.md
+++ b/README.md
@@ -3,51 +3,46 @@
 This is the source tree of RCSSA official website.
 
 
-## How to Run Locally
+## How to Build the Website
 
 ### Requirements
 
-`Jekyll` is required for compiling the web.
+* [Bundler](https://bundler.io/) will automatically help you configure the right versions of the dependencies.  If you don't have one, install one following [the instructions](https://bundler.io/).
+* Otherwise, if you really want to build the web on your own, `Jekyll` is required for compiling the web.  **Important**: You should use `jekyll 3.9.0` to build this website.  Newer `jekyll` versions causes errors.
+
+#### Build: Use Bunlder (Recommended)
+
+
+1. Let bundler install the dependencies.
+
+```bash
+bundle install
+```
+
+2. Run Jekyll
+
+```bash
+bundle exec jekyll serve
+```
+
+There you go!
+
+#### Build: Use your own Jekyll
+
+*Please skip this step if you use bundler*
 
 You can download and install Jekyll following the instructions here: [Jekyll Official Website](https://jekyllrb.com/docs/installation/).
 
-
-### Download and Server
-
-```shell
-git clone https://github.com/RCSSA/RCSSA-Web.git
-cd RCSSA-Web
+```bash
 jekyll serve
 ```
 
-Then access 127.0.0.1:4000 in your browser.
+### Access the built web
+
+Access 127.0.0.1:4000 in your browser.  (4000 is the default binding port for Jekyll.)
 
 ![image](./img/preview.png)
 
 ## Demo
 
 [RCSSA Website](https://rcssa.rice.edu/)
-
-## Maintainance
-
-### Update data
-All updates can be done by modifying the yaml files in _data.
-Make sure you are following the same format.
-
-To add/remove articles shown on the bottom of the landing page, go to
-articles.yml
-
-To add/remove person of the RCSSA board shown on the about page, go to
-board.yml
-
-To add/remove person of RCSSA webiste creators shown on the about page, go to
-board.yml
-
-To add/remove new merch products on shown on the merch page, go to
-merch.yml
-
-### Update social networks
-To add/remove social network links shown on the footer and about page, go to _config.yml and update the links accordingly. Again, make sure you are following the same format.
-
-
-


### PR DESCRIPTION
Newer versions of `Jekyll`, the "compiler" of our website, does not run correctly.  Currently `Jekyll 3.9.0` works and `Jekyll >= 4.0.0` crashes when building the web.

We need to control the Jekyll version. 

One easy way to do that is to use [Bundler](https://bundler.io/).

Instead of installing your own Jekyll, our users can just let Bundler install the right version of Jekyll.

So I added Bundler support (Gemfile) and updated README for building instructions.


This should be compatible with our current version.  If you're using your own Jekyll then just keep using it.